### PR TITLE
driver: Remove Wire.begin() call from begin function

### DIFF
--- a/examples/Pattern/Pattern.ino
+++ b/examples/Pattern/Pattern.ino
@@ -4,12 +4,15 @@
  */
 
 #include <TLC59116.h>
+#include <Wire.h>
 
 #define RESET_PIN D5
 
 TLC59116 board(0b1100000);
 
 void setup() {
+  Wire.begin()
+
   pinMode(RESET_PIN, OUTPUT);
   digitalWrite(RESET_PIN, LOW);
   delay(5);

--- a/examples/SanityCheck/SanityCheck.ino
+++ b/examples/SanityCheck/SanityCheck.ino
@@ -4,12 +4,15 @@
  */
 
 #include <TLC59116.h>
+#include <Wire.h>
 
 #define RESET_PIN D5
 
 TLC59116 board(0b1100000);
 
 void setup() {
+  Wire.begin();
+
   pinMode(RESET_PIN, OUTPUT);
   digitalWrite(RESET_PIN, LOW);
   delay(5);

--- a/src/TLC59116.cpp
+++ b/src/TLC59116.cpp
@@ -9,7 +9,6 @@
 TLC59116::TLC59116(uint8_t addr) { _addr = addr; }
 
 void TLC59116::begin() {
-    Wire.begin();
     /* Set MODE1 register to default values except bit [4] (OSC bit) */
     /* According to spec sheet, proper operation requires OSC bit to be set low */
     writeToReg(MODE1, 0x01);


### PR DESCRIPTION
This change makes the library more versatile as users may have multiple I2C devices connected on the bus, so initialization handling should not be implemented at the device level.

The assumption is made that the sketch will call `Wire.begin()` before attempting to interact with any LED drivers using this library.