### PR TITLE
Implement shadow registers

### DIFF
--- a/src/TLC59116.cpp
+++ b/src/TLC59116.cpp
@@ -6,7 +6,15 @@
 
 #include "TLC59116.h"
 
-TLC59116::TLC59116(uint8_t addr) { _addr = addr; }
+TLC59116::TLC59116(uint8_t addr) {
+    _addr = addr;
+    _enable_shadow_registers = true;
+}
+
+TLC59116::TLC59116(uint8_t addr, bool enable_shadow_registers) {
+    _addr = addr;
+    _enable_shadow_registers = enable_shadow_registers;
+}
 
 void TLC59116::begin() {
     /* Set MODE1 register to default values except bit [4] (OSC bit) */
@@ -28,7 +36,6 @@ void TLC59116::begin() {
     }
 }
 
-
 void TLC59116::setPattern(uint16_t pattern, uint8_t brightness) {
     for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
         if (pattern & (1 << channel)) {
@@ -40,7 +47,7 @@ void TLC59116::setPattern(uint16_t pattern, uint8_t brightness) {
 }
 
 void TLC59116::setBrightness(uint8_t channel, uint8_t brightness) {
-    if (_shadow_registers[channel] != brightness) {
+    if (!_enable_shadow_registers || _shadow_registers[channel] != brightness) {
         writeToReg(PWM0 + (channel & 0x0F), brightness);
         _shadow_registers[channel] = brightness;
     }

--- a/src/TLC59116.cpp
+++ b/src/TLC59116.cpp
@@ -24,6 +24,7 @@ void TLC59116::begin() {
     /* Initialize all channels to 0 (off) */
     for (uint8_t channel = 0; channel < NUM_CHANNELS; channel++) {
         setBrightness(channel, 0x00);
+        _shadow_registers[channel] = 0x00;
     }
 }
 
@@ -39,7 +40,10 @@ void TLC59116::setPattern(uint16_t pattern, uint8_t brightness) {
 }
 
 void TLC59116::setBrightness(uint8_t channel, uint8_t brightness) {
-    writeToReg(PWM0 + (channel & 0x0F), brightness);
+    if (_shadow_registers[channel] != brightness) {
+        writeToReg(PWM0 + (channel & 0x0F), brightness);
+        _shadow_registers[channel] = brightness;
+    }
 }
 
 void TLC59116::writeToReg(uint8_t reg, uint8_t val) {

--- a/src/TLC59116.h
+++ b/src/TLC59116.h
@@ -48,6 +48,7 @@
 class TLC59116 {
     private:
         uint8_t _addr;
+        uint8_t _shadow_registers[16];
         /* Write value to a register */
         void writeToReg(uint8_t reg, uint8_t val);
         

--- a/src/TLC59116.h
+++ b/src/TLC59116.h
@@ -49,12 +49,14 @@ class TLC59116 {
     private:
         uint8_t _addr;
         uint8_t _shadow_registers[16];
+        bool _enable_shadow_registers;
         /* Write value to a register */
         void writeToReg(uint8_t reg, uint8_t val);
         
     public:
-        /* Constructor */
+        /* Constructors */
         TLC59116(uint8_t addr);
+        TLC59116(uint8_t addr, bool _enable_shadow_registers);
         /* Initialize the driver and set all channels to default (0) */
         void begin();
         /* Set bits given by binary pattern to brightness value (0-255) */


### PR DESCRIPTION
- Add new constructor, which allows for explicitly enabling or disabling use of shadow registers.
- Optimize setting PWM channels that are already retain the value to be set